### PR TITLE
DOI-93 Selecting TODOS returns all results from all provinces 

### DIFF
--- a/disa-api-core/src/main/java/mz/org/fgh/disaapi/core/viralload/dao/ViralLoadDAO.java
+++ b/disa-api-core/src/main/java/mz/org/fgh/disaapi/core/viralload/dao/ViralLoadDAO.java
@@ -22,11 +22,11 @@ public interface ViralLoadDAO extends GenericDAO<ViralLoad, Long> {
 	class QUERY {
 		public static final String findByLocationCodeAndStatus = "SELECT vl FROM ViralLoad vl WHERE vl.healthFacilityLabCode IN (:locationCodes)and vl.viralLoadStatus = :viralLoadStatus AND vl.entityStatus = :entityStatus "
 																+ "AND vl.requestingProvinceName = :requestingProvinceName";
-		public static final String findByLocationCodeAndStatusSimple = "SELECT vl FROM ViralLoad vl WHERE vl.healthFacilityLabCode IN (:locationCodes)and vl.viralLoadStatus = :viralLoadStatus AND vl.entityStatus = :entityStatus";
+		public static final String findByLocationCodeAndStatusSimple = "SELECT vl FROM ViralLoad vl WHERE vl.healthFacilityLabCode IN (:locationCodes) and vl.viralLoadStatus = :viralLoadStatus AND vl.entityStatus = :entityStatus";
 		public static final String findByForm = "SELECT vl FROM ViralLoad vl "
 											  + "WHERE (COALESCE(:requestId, null) is null or vl.requestId = :requestId) "
 				                              + "AND (COALESCE(:nid, null) is null or vl.nid = :nid) "
-				                              + "AND (COALESCE(:healthFacilityLabCode, null) is null or vl.healthFacilityLabCode = :healthFacilityLabCode) "
+				                              + "AND (COALESCE(:healthFacilityLabCode, null) is null or vl.healthFacilityLabCode IN (:healthFacilityLabCode)) "
 				                              + "AND (COALESCE(:referringRequestID, null) is null or vl.referringRequestID = :referringRequestID) "
 				                              + "AND (COALESCE(:viralLoadStatus, null) is null or vl.viralLoadStatus = :viralLoadStatus) "
 											  + "AND vl.createdAt between :startDate and :endDate "
@@ -56,7 +56,7 @@ public interface ViralLoadDAO extends GenericDAO<ViralLoad, Long> {
 			EntityStatus entityStatus) throws BusinessException;
 	
 	List<ViralLoad> findByForm(String requestId, String nid, 
-			String healthFacilityLabCode, String referringRequestID, 
+			final List<String> healthFacilityLabCode, String referringRequestID, 
 			ViralLoadStatus viralLoadStatus, LocalDateTime startDate, LocalDateTime endDate, 
 			EntityStatus entityStatus) throws BusinessException;
 

--- a/disa-api-core/src/main/java/mz/org/fgh/disaapi/core/viralload/dao/ViralLoadDAOImpl.java
+++ b/disa-api-core/src/main/java/mz/org/fgh/disaapi/core/viralload/dao/ViralLoadDAOImpl.java
@@ -46,7 +46,7 @@ public class ViralLoadDAOImpl extends GenericDAOImpl<ViralLoad, Long> implements
 	
 	@Override
 	public List<ViralLoad> findByForm(String requestId, String nid, 
-			String healthFacilityLabCode, String referringRequestID, 
+			final List<String> healthFacilityLabCode, String referringRequestID, 
 			ViralLoadStatus viralLoadStatus, LocalDateTime startDate, LocalDateTime endDate, EntityStatus entityStatus) throws BusinessException {
 
 		return this.findByNamedQuery(ViralLoadDAO.QUERY_NAME.findByForm,

--- a/disa-api-core/src/main/java/mz/org/fgh/disaapi/core/viralload/service/ViralLoadQueryService.java
+++ b/disa-api-core/src/main/java/mz/org/fgh/disaapi/core/viralload/service/ViralLoadQueryService.java
@@ -22,7 +22,7 @@ public interface ViralLoadQueryService {
 	List<ViralLoad> findByLocationCodeAndStatus(List<String> locationCodes) throws BusinessException;
 
 	List<ViralLoad> findByForm(String requestId, String nid,
-			String healthFacilityLabCode, String ReferringRequestID,
+			List<String> healthFacilityLabCode, String ReferringRequestID,
 			ViralLoadStatus viralLoadStatus, LocalDateTime startDate, LocalDateTime endDate) throws BusinessException;
 
 	List<ViralLoad> findViralLoadByNid(List<String> nids) throws BusinessException;

--- a/disa-api-core/src/main/java/mz/org/fgh/disaapi/core/viralload/service/ViralLoadQueryServiceImpl.java
+++ b/disa-api-core/src/main/java/mz/org/fgh/disaapi/core/viralload/service/ViralLoadQueryServiceImpl.java
@@ -54,7 +54,7 @@ public class ViralLoadQueryServiceImpl implements ViralLoadQueryService {
 	
 	@Override
 	public List<ViralLoad> findByForm(String requestId, String nid, 
-			String healthFacilityLabCode, 
+			final List<String> healthFacilityLabCode, 
 			String referringRequestID, ViralLoadStatus viralLoadStatus, LocalDateTime startDate, LocalDateTime endDate) throws BusinessException {
 
 		return this.viralLoadDAO.findByForm(requestId, nid, 

--- a/disa-api-integ/src/main/java/mz/org/fgh/disaapi/integ/resources/viralload/ViralLoadResource.java
+++ b/disa-api-integ/src/main/java/mz/org/fgh/disaapi/integ/resources/viralload/ViralLoadResource.java
@@ -79,7 +79,7 @@ public class ViralLoadResource extends AbstractUserContext {
 	public Response findViralLoadsByForm(
 			@QueryParam("requestId") final String requestId,
 			@QueryParam("nid") final String nid,
-			@QueryParam("healthFacilityLabCode") final String healthFacilityLabCode,
+			@QueryParam("healthFacilityLabCode") final List<String> healthFacilityLabCode,
 			@QueryParam("referringRequestID") final String referringRequestID,
 			@QueryParam("viralLoadStatus") final ViralLoadStatus viralLoadStatus,
 			@QueryParam("startDate") final String strStartDate,
@@ -98,7 +98,7 @@ public class ViralLoadResource extends AbstractUserContext {
 	public Response _findViralLoadsByForm(
 			@QueryParam("requestId") final String requestId,
 			@QueryParam("nid") final String nid,
-			@QueryParam("healthFacilityLabCode") final String healthFacilityLabCode,
+			@QueryParam("healthFacilityLabCode") final List<String> healthFacilityLabCode,
 			@QueryParam("referringRequestID") final String referringRequestID,
 			@QueryParam("viralLoadStatus") final ViralLoadStatus viralLoadStatus,
 			@QueryParam("startDate") final String strStartDate,


### PR DESCRIPTION
Improvements:

1. Remove default values from disa global_property config. values that could create some confusion.
2. When selecting TODOS on the health facility code it should take into consideration all the values on disa.api.sisma.code property if there is more than one.