### PR TITLE
Marcar resultados com amostra_rejeitada como REJECTED e persistir na base de dados

### DIFF
--- a/disa-api-core/src/main/java/mz/org/fgh/disaapi/core/result/model/LabResult.java
+++ b/disa-api-core/src/main/java/mz/org/fgh/disaapi/core/result/model/LabResult.java
@@ -135,7 +135,7 @@ public abstract class LabResult extends GenericEntity {
 	private String labComments;
 
 	@Basic(optional = false)
-	@Column(name = "VIRAL_LOAD_STATUS", columnDefinition = "enum('PENDING','PROCESSED','NOT_PROCESSED')")
+	@Column(name = "VIRAL_LOAD_STATUS", columnDefinition = "enum('PENDING','PROCESSED','NOT_PROCESSED','REJECTED')")
 	@Enumerated(EnumType.STRING)
 	private LabResultStatus labResultStatus;
 

--- a/disa-api-core/src/main/java/mz/org/fgh/disaapi/core/result/model/LabResultStatus.java
+++ b/disa-api-core/src/main/java/mz/org/fgh/disaapi/core/result/model/LabResultStatus.java
@@ -5,5 +5,5 @@ package mz.org.fgh.disaapi.core.result.model;
  *
  */
 public enum LabResultStatus {
-	PENDING, PROCESSED, NOT_PROCESSED
+	PENDING, PROCESSED, NOT_PROCESSED, REJECTED
 }


### PR DESCRIPTION
Quando finalResult = amostra_rejeitada, o pipeline não deve processar o resultado, devendo atribuir LabResultStatus.REJECTED e persistir este estado na base de dados.